### PR TITLE
fix get_logger import

### DIFF
--- a/python/utils/model/inference_optimization.py
+++ b/python/utils/model/inference_optimization.py
@@ -32,7 +32,7 @@ try:
 except ImportError:
     TORCH_AVAILABLE = False
 
-from src.utils.logger import get_logger
+from ..logging.logger import get_logger
 
 logger = get_logger(__name__)
 


### PR DESCRIPTION
## Summary
- use consistent relative import for `get_logger` in `inference_optimization`

## Testing
- `python -m py_compile python/utils/model/inference_optimization.py`

------
https://chatgpt.com/codex/tasks/task_b_685e67fd2afc8323b892ffaa3a5a4ea2