### PR TITLE
Fix stray return and import placement

### DIFF
--- a/python/utils/logging/logger.py
+++ b/python/utils/logging/logger.py
@@ -39,6 +39,8 @@ import torch
 import numpy as np
 import psutil
 import platform
+from ..performance.experiment_logger import ExperimentLogger
+from ..performance.performance_tracker import PerformanceTracker
 
 # Import Rich for beautiful console output
 try:
@@ -475,13 +477,6 @@ class StructuredJSONHandler(logging.Handler):
                     f.write(json_data + '\n')
         except Exception:
             self.handleError(record)
-
-
-from ..performance.experiment_logger import ExperimentLogger
-
-
-from ..performance.performance_tracker import PerformanceTracker
-        return "\n".join(report)
 
 
 class IndentedRichHandler(RichHandler):


### PR DESCRIPTION
## Summary
- move ExperimentLogger and PerformanceTracker imports to main import block
- remove misplaced return statement in `StructuredJSONHandler`

## Testing
- `python -m py_compile python/utils/logging/logger.py`

------
https://chatgpt.com/codex/tasks/task_b_685e67df7ae48323bb5cda7c0c4c0d93